### PR TITLE
remove reliance on furnaces

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -42,8 +42,8 @@ data:extend({
     type = "recipe",
     name = "burner-assembling-machine",
     ingredients = {
-      { type = "item", name = "stone-furnace",   amount = 1 },
-      { type = "item", name = "iron-gear-wheel", amount = 5 }
+      { type = "item", name = "stone",   amount = 5 },
+      { type = "item", name = "iron-ore", amount = 10 }
     },
     results = {
       { type = "item", name = "burner-assembling-machine", amount = 1 }


### PR DESCRIPTION
this patch removes reliance of the burner assembling machine from furnaces by making it craftable from ores directly (and your own character can be used to mine so you're not relying on mining machines either)

Therefore this patch allows the burner assembling machine to be self sustainable, you need only it to craft from nothing

(goes hand in hand with the ability to respawn with this machine in inventory)